### PR TITLE
modify: gitignoreにsrcディレクトリを追記

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 /db/data/*
+/src


### PR DESCRIPTION
githubでinfra,front,backendのリポジトリを分けるため

理由：
フロントエンド、バックエンドをdockerを使った別のコンテナで開発する際に一つのリポジトリで管理するとすると.gitファイルをプロジェクトのルートにgit initで作成する必要があるが、そうするとvscodeの拡張機能でdockerのコンテナ内に入って作業をする際にプロジェクトのルートはコンテナ内でのエクスプローラーで参照していないためgitの恩恵を受けることができない。なのでリポジトリをinfra, front,backendに分けて開発することとしました。

確認お願いします。