### PR TITLE
modify: backend laravelでintervention imageを使えるようにするための修正

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,12 +1,13 @@
 FROM php:8.2-apache
 
 RUN apt-get update \
-  && apt-get -y install git libicu-dev libonig-dev libzip-dev unzip locales vim \
+  && apt-get -y install git libicu-dev libonig-dev libzip-dev unzip locales vim zlib1g-dev libpng-dev libjpeg-dev libfreetype6-dev libwebp-dev \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && locale-gen en_US.UTF-8 \
   && localedef -f UTF-8 -i en_US en_US.UTF-8 \
-  && docker-php-ext-install intl pdo_mysql zip bcmath \
+  && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
+  && docker-php-ext-install intl pdo_mysql zip bcmath gd exif \
   # composer config -g process-timeout 3600 && \
   # composer config -g repos.packagist composer https://packagist.org
   && pecl install xdebug \


### PR DESCRIPTION
_**issue:**_ #5 

_**背景：**_
backend laravelでintervension imageを使って画像ファイルのリサイズなどを行おうとしたときに
GD Library extension not available with this PHP installation
というエラーが出てリサイズが行えなかった

_**やったこと：**_

- [ ] phpのDockerFileにgd, exifなどintervension imageに必要なライブラリと、ローカルではなくdocker環境により必要となる部分の記述を追加

_**参考サイト：**_
https://poppotennis.com/posts/docker-intervention-image
https://ketukara.com/programing/2034/

レビューお願いします

ライブラリとしてgd, exifなどを追加している